### PR TITLE
fix(util): find_library

### DIFF
--- a/shadowsocks/crypto/util.py
+++ b/shadowsocks/crypto/util.py
@@ -51,7 +51,8 @@ def find_library(possible_lib_names, search_symbol, library_name):
     lib_names = []
     for lib_name in possible_lib_names:
         lib_names.append(lib_name)
-        lib_names.append('lib' + lib_name)
+        if lib_name != 'crypto':
+            lib_names.append('lib' + lib_name)
 
     for name in lib_names:
         if os.name == "nt":


### PR DESCRIPTION
    Fix FileNotFoundError: [Errno 2] No such file or directory: b'liblibcrypto.a' .

    -  ctypes.util.find_library(name):
        尝试寻找一个库然后返回其路径名， name 是库名称, 且去除了 lib 等前缀和
         .so 、 .dylib 、版本号等后缀